### PR TITLE
Remove closure from 'after_setup_theme' action

### DIFF
--- a/fm-zones.php
+++ b/fm-zones.php
@@ -35,6 +35,7 @@ define( 'FMZ_PATH', dirname( __FILE__ ) );
 define( 'FMZ_URL', trailingslashit( plugins_url( '', __FILE__ ) ) );
 define( 'FMZ_VERSION', '0.1.3' );
 
-add_action( 'after_setup_theme', function() {
+function after_setup_theme() {
 	require_once( __DIR__ . '/php/class-fieldmanager-zone-field.php' );
-} );
+}
+add_action( 'after_setup_theme', 'after_setup_theme' );


### PR DESCRIPTION
fm-zones.php defined the 'after_setup_theme' action as a closure. Since that makes wp_filters unserializable, this pull request creates a function instead.