### PR TITLE
Remove 'post' from query arguments

### DIFF
--- a/php/class-fieldmanager-zone-field.php
+++ b/php/class-fieldmanager-zone-field.php
@@ -93,7 +93,6 @@ if ( class_exists( 'Fieldmanager_Field' ) && ! class_exists( 'Fieldmanager_Zone_
 		public function get_posts( $args = array() ) {
 			$args = array_merge(
 				array(
-					'post_type' => 'post',
 					'post_status' => 'publish',
 					'posts_per_page' => 10,
 				),


### PR DESCRIPTION
Can we open this up to other post types in the query? I know that it would be nice to default back to 'post', but in WP environments where multiple post types are used, it would be nice to slot different post types in the same "zone". Looks like you had that thought as well, since you display the content type on the UI.