### PR TITLE
Fix datasource back-compat to stop trampling queries

### DIFF
--- a/php/class-fieldmanager-datasource-zone-field.php
+++ b/php/class-fieldmanager-datasource-zone-field.php
@@ -88,7 +88,7 @@ class Fieldmanager_Datasource_Zone_Field extends Fieldmanager_Datasource_Post {
 
 		$data = array(
 			'success' => true,
-			'data' => $items,
+			'data'    => $items,
 		);
 
 		return $data;
@@ -153,7 +153,7 @@ class Fieldmanager_Datasource_Zone_Field extends Fieldmanager_Datasource_Post {
 	/**
 	 * Exclude already-chosen posts
 	 *
-	 * @param $excluded Post IDs already in use.
+	 * @param array $excluded Post IDs already in use.
 	 * @return array
 	 */
 	public function set_excluded_posts( $excluded ) {

--- a/php/class-fieldmanager-datasource-zone-field.php
+++ b/php/class-fieldmanager-datasource-zone-field.php
@@ -10,6 +10,16 @@
  */
 class Fieldmanager_Datasource_Zone_Field extends Fieldmanager_Datasource_Post {
 	/**
+	 * Unmodified query args
+	 *
+	 * Used to restore original query args after filtering
+	 * for specific datasource request.
+	 *
+	 * @var array|null
+	 */
+	protected $original_query_args = null;
+
+	/**
 	 * Set up the datasource
 	 *
 	 * @param array $options Datasource options.
@@ -34,8 +44,12 @@ class Fieldmanager_Datasource_Zone_Field extends Fieldmanager_Datasource_Post {
 		/**
 		 * Filter query arguments, for back-compat
 		 *
+		 * Original query arguments are retained and restored
+		 * to make the filter behave as if it's datasource-specific.
+		 *
 		 * @param array $args An array of WP_Query arguments.
 		 */
+		$this->original_query_args = $this->query_args;
 		$this->query_args = apply_filters( 'fm_zones_get_posts_query_args', $this->query_args );
 
 		// Backcompat sorting.
@@ -43,7 +57,12 @@ class Fieldmanager_Datasource_Zone_Field extends Fieldmanager_Datasource_Post {
 			$this->query_args['orderby'] = 'relevance';
 		}
 
-		return $this->do_get_items( $fragment );
+		$items = $this->do_get_items( $fragment );
+
+		$this->query_args = $this->original_query_args;
+		$this->original_query_args = null;
+
+		return $items;
 	}
 
 	/**

--- a/php/class-fieldmanager-zone-field.php
+++ b/php/class-fieldmanager-zone-field.php
@@ -213,7 +213,7 @@ class Fieldmanager_Zone_Field extends Fieldmanager_Field {
 	public function get_posts( $args = array() ) {
 		$args = array_merge(
 			$this->default_args,
-			$this->query_args,
+			$this->datasource->query_args,
 			$args
 		);
 

--- a/tests/test-datasource.php
+++ b/tests/test-datasource.php
@@ -92,4 +92,34 @@ class Test_Fieldmanager_Datasource_Zone_Field extends WP_UnitTestCase {
 		$this->assertEquals( 3, count( $items ) );
 		$this->assertEquals( false, in_array( $this->post_id, $ids, true ), __( 'Failed asserting that excluded post was excluded.', 'fm-zones' ) );
 	}
+
+	public function test_query_restoration() {
+		$expected = array(
+			'post_type'      => 'page',
+			'posts_per_page' => 2,
+		);
+
+		$datasource = new Fieldmanager_Datasource_Zone_Field( array(
+			'query_args' => $expected,
+		) );
+
+		$items = $datasource->get_items();
+
+		$this->assertEquals( 0, count( $items ) );
+		$this->assertEquals( $expected, $datasource->query_args );
+
+		add_filter( 'fm_zones_get_posts_query_args', '__return_empty_array' );
+
+		$items = $datasource->get_items();
+
+		// Can't check that the query args changed, so we observe the results.
+		$this->assertEquals( 4, count( $items ) );
+
+		remove_filter( 'fm_zones_get_posts_query_args', '__return_empty_array' );
+
+		$items = $datasource->get_items();
+
+		$this->assertEquals( 0, count( $items ) );
+		$this->assertEquals( $expected, $datasource->query_args );
+	}
 }

--- a/tests/test-field.php
+++ b/tests/test-field.php
@@ -107,5 +107,4 @@ class Test_Fieldmanager_Zone_Field extends WP_UnitTestCase {
 		$items = $items['data'];
 		$this->assertSame( $this->data_posts[2]->ID, $items[0]['id'] );
 	}
-
 }


### PR DESCRIPTION
Backcompat added in #32 as part of introducing datasource support included a filter. As initially implemented, this backcompat pollutes the datasource's query args when called multiple times in a single request.