### PR TITLE
Add Composer Package Type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
   "name": "alleyinteractive/fm-zones",
+  "type": "wordpress-plugin",
   "authors": [
     {
       "name": "Matthew Boynes",


### PR DESCRIPTION
Adds the `wordpress-plugin` type to the composer json